### PR TITLE
Add sphinx requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx~=7.2.6
+sphinx-autodoc-typehints~=2.0.0
+sphinxawesome-theme~=5.1.1
+myst-parser~=2.0.0
+pygit2~=1.14.1


### PR DESCRIPTION
- Adds `docs/requirements.txt` with the packages that are only required for generating the Sphinx documentation