### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,20 +17,20 @@ classifiers = [
 ]
 dependencies= [
     # Machine Learning Libraries
-    "numpy>=1.24.4",
+    "numpy~=1.26.4",
 
     # Parallel Processing Libraries
-    "dask>=2023.12.0",
+    "dask~=2023.12.0",
 
     # Data Processing Libraries
-    "pandas>=1.3.3",
+    "pandas~=1.3.3",
 
     # Parquet
-    "pyarrow>=6.0.0",
+    "pyarrow~=6.0.0",
 
     # PyTorch
-    "torch>=2.1.2+cu118",
+    "torch~=2.2.1",
 
     # Agogos
-    "agogos>=0.2.0",
+    "agogos~=0.2.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agogos>=0.2.0
+agogos==0.2.0
 annotated-types==0.6.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
@@ -23,7 +23,7 @@ pandas==2.2.1
 partd==1.4.1
 pillow==10.2.0
 pluggy==1.4.0
-pyarrow>=6.0.0
+pyarrow==6.0.0
 pytest==8.0.2
 pytest-cov==4.1.0
 PyYAML==6.0.1


### PR DESCRIPTION
Fix this issue when trying to install `epochalyst`:

![image](https://github.com/TeamEpochGithub/epochalyst/assets/33672881/2c49d65b-801a-4acc-a22c-a31e848e1b54)

Yeah, PyTorch kinda sucks when it comes to managing its versions. 