### PR TITLE
Concat datasets abstraction

### DIFF
--- a/epochalyst/pipeline/model/training/torch_trainer.py
+++ b/epochalyst/pipeline/model/training/torch_trainer.py
@@ -1,9 +1,11 @@
+import bisect
 import copy
 import functools
 import gc
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Callable
+from typing import Annotated, Any, Callable, Iterable, List, TypeVar
+import warnings
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +20,9 @@ from tqdm import tqdm
 from epochalyst._core._pipeline._custom_data_parallel import _CustomDataParallel
 from epochalyst.logging.section_separator import print_section_separator
 from epochalyst.pipeline.model.training.training_block import TrainingBlock
+from torch.utils.data import ConcatDataset, IterableDataset
 
+T = TypeVar('T', bound=Dataset)
 
 @dataclass
 class TorchTrainer(TrainingBlock):
@@ -556,11 +560,11 @@ class TorchTrainer(TrainingBlock):
 
     def _concat_datasets(
         self,
-        train_dataset: Dataset[tuple[Tensor, ...]],
-        test_dataset: Dataset[tuple[Tensor, ...]],
+        train_dataset: T,
+        test_dataset: T,
         train_indices: list[int],
         test_indices: list[int],
-    ) -> Dataset[tuple[Tensor, ...]]:
+    ) -> T:
         """
         Concatenate the training and test datasets according to original order specified by train_indices and test_indices.
 
@@ -571,28 +575,49 @@ class TorchTrainer(TrainingBlock):
         :return: A new dataset containing the concatenated data in the original order.
         """
 
-        # Combine the indices and sort them alongside their corresponding dataset identifier ('train' or 'test')
-        combined_indices = train_indices + test_indices
-        dataset_labels = ["train"] * len(train_indices) + ["test"] * len(test_indices)
-        sorted_combined = sorted(
-            zip(combined_indices, dataset_labels), key=lambda x: x[0]
-        )
+        return TrainTestDataset(train_dataset, test_dataset, train_indices, test_indices)
 
-        # Create a new list to hold the concatenated dataset
-        concatenated_dataset = []
 
-        # Iterate over the sorted combination of indices and dataset labels
-        for index, dataset_label in sorted_combined:
-            if dataset_label == "train":
-                # Calculate the original index in the train dataset
-                original_index = train_indices.index(index)
-                concatenated_dataset.append(train_dataset[original_index])
-            else:
-                # Calculate the original index in the test dataset
-                original_index = test_indices.index(index)
-                concatenated_dataset.append(test_dataset[original_index])
+T_co = TypeVar('T_co', covariant=True)
 
-        return TensorDataset(
-            torch.tensor([[x[0]] for x in concatenated_dataset]),
-            torch.tensor([[x[1]] for x in concatenated_dataset]),
-        )
+class TrainTestDataset(Dataset[T_co]):
+    r"""Dataset as a concatenation of multiple datasets.
+
+    This class is useful to assemble different existing datasets.
+
+    Args:
+        datasets (sequence): List of datasets to be concatenated
+    """
+    train_dataset: Dataset[T_co]
+    test_dataset: Dataset[T_co]
+    train_indices: List[int]
+    test_indices: List[int]
+
+    def __init__(self, train_dataset: Dataset[T_co], test_dataset: Dataset[T_co], train_indices: List[int], test_indices: List[int]) -> None:
+        super().__init__()
+        assert len(train_dataset) == len(train_indices), "Train_dataset should be the same length as train_indices"
+        assert len(test_dataset) == len(test_indices), "Test_dataset should be the same length as test_indices"
+        self.train_dataset = train_dataset
+        self.test_dataset = test_dataset
+        self.train_indices = train_indices
+        self.test_indices = test_indices
+
+    def __len__(self):
+        return len(self.train_dataset) + len(self.test_dataset)
+
+    def __getitem__(self, idx):
+        if idx < 0:
+            if -idx > len(self):
+                raise ValueError("absolute value of index should not exceed dataset length")
+            idx = len(self) + idx
+
+        item = self.train_dataset[0]
+
+        if idx in self.train_indices:
+            train_index = self.train_indices.index(idx)
+            item = self.train_dataset[train_index]
+        else:
+            test_index = self.test_indices.index(idx)
+            item = self.test_dataset[test_index]
+
+        return item


### PR DESCRIPTION
- Use a custom version of ConcatDatasets from torch.utils.data
- Rewrite to return items in the original order
- Change _concatentate_datasets to use the new class.