### PR TITLE
Ability to disable early stopping

### DIFF
--- a/epochalyst/pipeline/model/training/torch_trainer.py
+++ b/epochalyst/pipeline/model/training/torch_trainer.py
@@ -558,17 +558,18 @@ class TorchTrainer(TrainingBlock):
         """
 
         # Store the best model so far based on validation loss
-        if self.last_val_loss < self.lowest_val_loss and self.patience != -1:
-            self.lowest_val_loss = self.last_val_loss
-            self.best_model_state_dict = copy.deepcopy(self.model.state_dict())
-            self.early_stopping_counter = 0
-        else:
-            self.early_stopping_counter += 1
-            if self.early_stopping_counter >= self.patience and self.patience != -1:
-                self.log_to_terminal(
-                    f"Early stopping after {self.early_stopping_counter} epochs"
-                )
-                return True
+        if self.patience != -1:
+            if self.last_val_loss < self.lowest_val_loss:
+                self.lowest_val_loss = self.last_val_loss
+                self.best_model_state_dict = copy.deepcopy(self.model.state_dict())
+                self.early_stopping_counter = 0
+            else:
+                self.early_stopping_counter += 1
+                if self.early_stopping_counter >= self.patience:
+                    self.log_to_terminal(
+                        f"Early stopping after {self.early_stopping_counter} epochs"
+                    )
+                    return True
         return False
 
     def _concat_datasets(

--- a/epochalyst/pipeline/model/training/torch_trainer.py
+++ b/epochalyst/pipeline/model/training/torch_trainer.py
@@ -558,13 +558,13 @@ class TorchTrainer(TrainingBlock):
         """
 
         # Store the best model so far based on validation loss
-        if self.last_val_loss < self.lowest_val_loss:
+        if self.last_val_loss < self.lowest_val_loss and self.patience != -1:
             self.lowest_val_loss = self.last_val_loss
             self.best_model_state_dict = copy.deepcopy(self.model.state_dict())
             self.early_stopping_counter = 0
         else:
             self.early_stopping_counter += 1
-            if self.early_stopping_counter >= self.patience:
+            if self.early_stopping_counter >= self.patience and self.patience != -1:
                 self.log_to_terminal(
                     f"Early stopping after {self.early_stopping_counter} epochs"
                 )

--- a/tests/pipeline/model/training/test_torch_trainer.py
+++ b/tests/pipeline/model/training/test_torch_trainer.py
@@ -299,3 +299,29 @@ class TestTorchTrainer:
             tt.train(x, y, train_indices=[0, 1, 2, 3, 4, 5, 6, 7], test_indices=[8, 9])
 
         remove_cache_files()
+
+    def test_early_stopping_no_patience(self):
+        tt = self.FullyImplementedTorchTrainer(
+        model=self.simple_model,
+        criterion=torch.nn.MSELoss(),
+        optimizer=self.optimizer,
+        patience=-1,
+        )
+        tt.last_val_loss = 0.5
+        tt.lowest_val_loss = 0.3
+        tt.model = torch.nn.Linear(1, 1)
+        tt.best_model_state_dict = tt.model.state_dict()
+        tt.early_stopping_counter = 0
+
+        # Call the _early_stopping method
+        # This increments the counter
+        result = tt._early_stopping()
+
+        # Assert that the best model is not updated
+        assert tt.best_model_state_dict == tt.model.state_dict()
+
+        # Assert that the early stopping counter is incremented
+        assert tt.early_stopping_counter == 1
+
+        # Assert that the method returns False
+        assert result is False


### PR DESCRIPTION
Allows disabling early stopping if patience is specified as -1. It also shouldn't keep track of the best model so It shouldn't be able to overwrite the model