### PR TITLE
Deploy documentation on GitHub pages

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -2,7 +2,7 @@ name: Deploy Sphinx documentation to Pages
 
 on:
   push:
-    branches: [ '*' ]  # Branch to trigger deployment
+    branches: [ main ]  # Branch to trigger deployment
 
 jobs:
   pages:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,20 @@
+name: Deploy Sphinx documentation to Pages
+
+on:
+  push:
+    branches: [ '*' ]  # Branch to trigger deployment
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: sphinx-notes/pages@v3
+        with:
+          python_version: 3.12

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,22 +1,28 @@
-.. Epochalyst documentation master file, created by
-   sphinx-quickstart on Wed Dec 13 14:18:51 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Epochalyst
-=======================================
-
 .. raw:: html
 
    <div class="epochalyst-logo"></div>
 
-Contents:
+-------------------
+
+Index
+=========================
+
+.. toctree::
+   :maxdepth: 2
+
+   readme_link
+
+
+-------------------
+
+API
+=========================
 
 .. autosummary::
    :toctree: _autosummary
    :recursive:
 
-   epochalyst
+   epochalyst.epochalyst
 
 Indices and tables
 ==================

--- a/docs/readme_link.rst
+++ b/docs/readme_link.rst
@@ -1,0 +1,5 @@
+README
+==============
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,7 @@
-sphinx~=7.2.6
-sphinx-autodoc-typehints~=2.0.0
-sphinxawesome-theme~=5.1.1
-myst-parser~=2.0.0
-pygit2~=1.14.1
+sphinx==7.2.6
+sphinx-autodoc-typehints==2.0.0
+sphinxawesome-theme==5.1.3
+myst-parser==2.0.0
+pygit2==1.14.1
+agogos==0.4.0
+torch==2.2.2


### PR DESCRIPTION
Title. Uses the same code as the one for [Woogle Maps](https://github.com/Jeffrey-Lim/woogle-maps/blob/main/.github/workflows/publish-docs.yaml). It didn't work [here](https://github.com/TeamEpochGithub/epochalyst/actions/runs/8784286497), but it seems to be some permission issue that Emiel or Brian might need to take a look at. 
