### PR TITLE
ENH: Only test on Py3.10 for version branches

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,17 +7,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v3
-        with:
-          python-version: 3.11
-
-      - run: |
-          pip install build
-          python -m build
-
-      - uses: actions/upload-artifact@v3
+      - name: Check out repository
+        uses: actions/checkout@v4.1.6
+      - name: Install the latest version of Rye
+        uses: eifinger/setup-rye@v3.0.2
+      - name: Build the package
+        run: rye build
+      - uses: actions/upload-artifact@v4.3.3
         with:
           path: ./dist
 
@@ -31,9 +27,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.7
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.9.0
         with:
           packages-dir: artifact/

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -40,13 +40,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.6
 
-    - uses: actions/setup-python@v5.1.0
-      with:
-        python-version: 3.10.14
+    - name: Install the latest version of rye
+      uses: eifinger/setup-rye@v3.0.2
 
-    - run: |
-        pip install build
-        python -m build
+    - name: Build the package
+      run: rye build
 
     - uses: actions/upload-artifact@v4.3.3
       with:

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.11
+        python-version: 3.10
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Run pre-commit
@@ -20,14 +20,10 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim
+      image: python:3.10-slim
       env:
         NODE_VERSION: 20
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Install Node.js
@@ -37,10 +33,10 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.10
 
     - name: Create virtual environment
       run: python -m venv venv
@@ -67,7 +63,7 @@ jobs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.11
+        python-version: 3.10
 
     - run: |
         pip install build

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -19,19 +19,15 @@ jobs:
 
   pytest:
     runs-on: ubuntu-latest
-
     steps:
     - name: Check out repository
       uses: actions/checkout@v4.1.6
       with:
         fetch-depth: 0
-
-    - name: Install the latest version of rye
+    - name: Install the latest version of Rye
       uses: eifinger/setup-rye@v3.0.2
-
     - name: Setup the environment
       run: rye sync --all-features
-
     - name: Test with pytest
       run: rye run pytest --cov=epochalyst --cov-branch --cov-fail-under=95 tests
 
@@ -39,13 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.6
-
-    - name: Install the latest version of rye
+    - name: Install the latest version of Rye
       uses: eifinger/setup-rye@v3.0.2
-
     - name: Build the package
       run: rye build
-
-    - uses: actions/upload-artifact@v4.3.3
-      with:
-        path: ./dist

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -1,8 +1,8 @@
 name: Version Branch CI/CD
 
 on:
-    pull_request:
-        branches: ["v*"]
+  pull_request:
+    branches: ["v*"]
 
 jobs:
   pre-commit:
@@ -34,8 +34,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Check out repository
+      uses: actions/checkout@v4.1.6
     - name: Install the latest version of Rye
       uses: eifinger/setup-rye@v3.0.2
     - name: Build the package
       run: rye build
+    - uses: actions/upload-artifact@v4.3.3
+      with:
+        path: ./dist

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -48,6 +48,6 @@ jobs:
         pip install build
         python -m build
 
-    - uses: actions/upload-artifact@v3.3.3
+    - uses: actions/upload-artifact@v4.3.3
       with:
         path: ./dist

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: 3.10.14
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Run pre-commit
@@ -20,7 +20,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     container:
-      image: python:3.10-slim
+      image: python:3.10.14-slim
       env:
         NODE_VERSION: 20
 
@@ -33,10 +33,10 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10.14
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: 3.10.14
 
     - name: Create virtual environment
       run: python -m venv venv
@@ -63,7 +63,7 @@ jobs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: 3.10.14
 
     - run: |
         pip install build

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -8,8 +8,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4.1.6
+    - uses: actions/setup-python@v5.1.0
       with:
         python-version: 3.10.14
     - name: Install pre-commit
@@ -19,49 +19,28 @@ jobs:
 
   pytest:
     runs-on: ubuntu-latest
-    container:
-      image: python:3.10.14-slim
-      env:
-        NODE_VERSION: 20
-
 
     steps:
-    - name: Install Node.js
-      uses: actions/setup-node@v3
+    - name: Check out repository
+      uses: actions/checkout@v4.1.6
       with:
-        node-version: ${{ env.NODE_VERSION }}
+        fetch-depth: 0
 
-    - uses: actions/checkout@v3
+    - name: Install the latest version of rye
+      uses: eifinger/setup-rye@v3.0.2
 
-    - name: Set up Python 3.10.14
-      uses: actions/setup-python@v3
-      with:
-        python-version: 3.10.14
-
-    - name: Create virtual environment
-      run: python -m venv venv
-
-    - name: Activate virtual environment
-      run: |
-        . venv/bin/activate
-
-    - name: Install dependencies
-      run: |
-        venv/bin/python -m pip install --upgrade pip
-        venv/bin/python -m pip install pytest
-        venv/bin/python -m pip install -r requirements-dev.lock
-        venv/bin/python -m pip install pytest-cov coverage
+    - name: Setup the environment
+      run: rye sync --all-features
 
     - name: Test with pytest
-      run: |
-        venv/bin/python -m pytest --cov=epochalyst --cov-branch --cov-fail-under=95 tests
+      run: rye run pytest --cov=epochalyst --cov-branch --cov-fail-under=95 tests
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.6
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5.1.0
       with:
         python-version: 3.10.14
 
@@ -69,6 +48,6 @@ jobs:
         pip install build
         python -m build
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v3.3.3
       with:
         path: ./dist


### PR DESCRIPTION
PRs will only get tested for Python 3.10 now, while it will still be tested for 3.10, 3.11, and 3.12 for main. 

I also used Rye to set up the environment faster and to build the package in both the version branch testing as well as for publishing the package. Rye speeds up both of these processes and it still works exactly the same, so it basically saves GH action minutes for free. I also wanted to do it for the main branch testing, but it might take some more time to get it to work for other Python versions and I feel like using Rye for in GH actions is already a bit out of scope for this issue. 