### PR TITLE
CI: Configure pre-commit.ci

### DIFF
--- a/.github/workflows/main-branch-testing.yml
+++ b/.github/workflows/main-branch-testing.yml
@@ -7,6 +7,20 @@ on:
     branches: [ "main" ]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10.14
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.10.14
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
   build:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/main-branch-testing.yml
+++ b/.github/workflows/main-branch-testing.yml
@@ -7,20 +7,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4.1.6
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.10.14
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: 3.10.14
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-
   build:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/main-branch-testing.yml
+++ b/.github/workflows/main-branch-testing.yml
@@ -7,18 +7,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-      with:
-        python-version: 3.11
-    - name: Install pre-commit
-      run: pip install pre-commit
-    - name: Run pre-commit
-      run: pre-commit run --all-files
-
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/main-branch-testing.yml
+++ b/.github/workflows/main-branch-testing.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     container:
       image: python:3.11-slim

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,22 @@
+name: Static Analysis
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main", "v*" ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10.14
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.10.14
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -5,18 +5,6 @@ on:
         branches: ["v*"]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-      with:
-        python-version: 3.11
-    - name: Install pre-commit
-      run: pip install pre-commit
-    - name: Run pre-commit
-      run: pre-commit run --all-files
-
   pytest:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -5,20 +5,6 @@ on:
     branches: ["v*"]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4.1.6
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.10.14
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: 3.10.14
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -19,6 +19,20 @@ jobs:
     - name: Test with pytest
       run: rye run pytest --cov=epochalyst --cov-branch --cov-fail-under=95 tests
 
+  mypy:
+    runs-on: ubuntu-latest
+    needs: pytest
+    steps:
+      - name: Run MyPy
+        uses: tsuyoshicho/action-mypy@v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail_on_error: true
+          setup_method: adaptive
+          setup_command: "rye add mypy"
+          execute_command: "rye run mypy"
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -21,8 +21,15 @@ jobs:
 
   mypy:
     runs-on: ubuntu-latest
-    needs: pytest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Install the latest version of Rye
+        uses: eifinger/setup-rye@v3.0.2
+      - name: Setup the environment
+        run: rye sync --all-features
       - name: Run MyPy
         uses: tsuyoshicho/action-mypy@v4.1.0
         with:

--- a/.github/workflows/version-branch-testing.yml
+++ b/.github/workflows/version-branch-testing.yml
@@ -5,6 +5,20 @@ on:
     branches: ["v*"]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10.14
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.10.14
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
   pytest:
     runs-on: ubuntu-latest
     steps:
@@ -18,27 +32,6 @@ jobs:
       run: rye sync --all-features
     - name: Test with pytest
       run: rye run pytest --cov=epochalyst --cov-branch --cov-fail-under=95 tests
-
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4.1.6
-        with:
-          fetch-depth: 0
-      - name: Install the latest version of Rye
-        uses: eifinger/setup-rye@v3.0.2
-      - name: Setup the environment
-        run: rye sync --all-features
-      - name: Run MyPy
-        uses: tsuyoshicho/action-mypy@v4.1.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          fail_on_error: true
-          setup_method: adaptive
-          setup_command: "rye add mypy"
-          execute_command: "rye run mypy"
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,15 +68,15 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - numpy==1.26.4
-          - pandas-stubs>=2.2.2.240514
-#          - torch==2.3.1
-          - dask==2024.6.2
-          - typing_extensions==4.9.0
-          - annotated-types==0.7.0
-          - polars==0.20.31
-          - kornia==0.7.2
-          - timm==1.0.7
+#          - numpy==1.26.4
+#          - pandas-stubs>=2.2.2.240514
+          - torch==2.3.1
+#          - dask==2024.6.2
+#          - typing_extensions==4.9.0
+#          - annotated-types==0.7.0
+#          - polars==0.20.31
+#          - kornia==0.7.2
+#          - timm==1.0.7
         args:
           - "--fast-module-lookup"
           - "--disallow-any-generics"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,8 +75,8 @@ repos:
           - typing_extensions==4.9.0
           - annotated-types==0.7.0
           - polars==0.20.31
-#          - kornia==0.7.2
-#          - timm==1.0.7
+          - kornia==0.7.2
+          - timm==1.0.7
         args:
           - "--fast-module-lookup"
           - "--disallow-any-generics"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 exclude: ^(external/|venv/|.venv/|tests/|.cache)
+ci:
+  skip: [mypy]
 repos:
   - repo: local  # Remove this when a new version of pre-commit-hooks (>4.6.0) is released
     hooks:
@@ -68,15 +70,16 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-#          - numpy==1.26.4
-#          - pandas-stubs>=2.2.2.240514
-          - torch==2.3.1
-#          - dask==2024.6.2
-#          - typing_extensions==4.9.0
-#          - annotated-types==0.7.0
-#          - polars==0.20.31
-#          - kornia==0.7.2
-#          - timm==1.0.7
+          - "--extra-index-url=https://download.pytorch.org/whl/cpu"
+          - numpy==1.26.4
+          - pandas-stubs>=2.2.2.240514
+          - torch==2.3.1+cpu
+          - dask==2024.6.2
+          - typing_extensions==4.9.0
+          - annotated-types==0.7.0
+          - polars==0.20.31
+          - kornia==0.7.2
+          - timm==1.0.7
         args:
           - "--fast-module-lookup"
           - "--disallow-any-generics"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,11 +70,11 @@ repos:
         additional_dependencies:
           - numpy==1.26.4
           - pandas-stubs>=2.2.2.240514
-          - torch==2.3.1
-#          - dask==2024.6.2
+#          - torch==2.3.1
+          - dask==2024.6.2
           - typing_extensions==4.9.0
           - annotated-types==0.7.0
-#          - polars==0.20.31
+          - polars==0.20.31
 #          - kornia==0.7.2
 #          - timm==1.0.7
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         additional_dependencies:
           - numpy==1.26.4
           - pandas-stubs>=2.2.2.240514
-#          - torch==2.3.1
+          - torch==2.3.1
 #          - dask==2024.6.2
           - typing_extensions==4.9.0
           - annotated-types==0.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,14 +70,13 @@ repos:
         additional_dependencies:
           - numpy==1.26.4
           - pandas-stubs>=2.2.2.240514
-          - matplotlib==3.8.4
-          - torch==2.3.1
-          - dask==2024.6.2
+#          - torch==2.3.1
+#          - dask==2024.6.2
           - typing_extensions==4.9.0
           - annotated-types==0.7.0
-          - polars==0.20.31
-          - kornia==0.7.2
-          - timm==1.0.7
+#          - polars==0.20.31
+#          - kornia==0.7.2
+#          - timm==1.0.7
         args:
           - "--fast-module-lookup"
           - "--disallow-any-generics"


### PR DESCRIPTION
All we need to do in the code is simply remove pre-commit from our GitHub Actions. 

It is now up to @TeamEpochNL to enable the pre-commit.ci GitHub App for the epochalyst repo. 

**Edit**: Okay, apparently it wasn't that easy. Pre-commit.ci refuses to use MyPy with torch as a dependency because torch is simply too big, even just the CPU version. If we still want to use pre-commit.ci, we have to skip MyPy in the CI and locally make sure that it still runs without errors. We could use a different GH action for running MyPy, but it's a bit finicky to get it to work exactly the same as when you run pre-commit. 

We can also make use of the [pre-commit GH action](https://github.com/marketplace/actions/pre-commit) instead, which at least still caches the pre-commit environment. I added that approach here as well. If we want to go with this approach (which I think is the best option for now), @TeamEpochNL simply needs to disable pre-commit.ci for this repo (or not, it doesn't matter that much) and then we can merge this. 

Also, please squash the commits before merging. The commit history always gets really dirty when testing CI stuff.